### PR TITLE
Migrating 'glue' code interfacing with Neovim RPC from Vimscript to Lua

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 neovim-lib = "0.6.1"
-rspotify = {version = "0.11.7", features = ["cli", "env-file"]}
+rspotify = {version = "*", features = ["cli", "env-file"]}
 env_logger = "0.10.0"
 tokio = {version = "1.29.1", features = ["full"]}
 webbrowser = "0.8.10"

--- a/plugin/lua/rpc_andrea.lua
+++ b/plugin/lua/rpc_andrea.lua
@@ -1,0 +1,350 @@
+--     Copyright 2020 Cedraro Andrea <a.cedraro@gmail.com>
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+--    limitations under the License.
+
+local parsers = require("nvim-treesitter.parsers")
+local tsq = require("vim.treesitter.query")
+local queries = require("nvim-treesitter.query")
+
+-- TODO: (andrea): find out if there is a better way in lua.
+local plugin_directory = vim.fn.fnamemodify(vim.fn.resolve(vim.fn.expand("<sfile>:p")), ":h:h")
+
+local last_request = {
+	id = 0,
+	startcol = 0,
+}
+local remote_job_id = nil
+
+local buffers = {}
+
+local Buffer = {}
+
+-- NOTE: This creates a new buffer? I don't think I need that
+function Buffer:new(bufnr)
+	local health = {}
+
+	local ft = vim.bo.filetype
+	if ft == "" then
+		health.no_ft = true
+	end
+
+	if not parsers.has_parser() then
+		health.missing_parser = true
+	end
+
+	local lang = parsers.ft_to_lang(ft)
+	local query = queries.get_query(lang, "completion")
+	if query == nil then
+		health.missing_query = true
+	end
+
+	local threshold = (vim.g.ycm_disable_for_files_larger_than_kb or 5000) * 1024
+	local fp = vim.api.nvim_buf_get_name(bufnr)
+	if vim.fn.getfsize(fp) > threshold then
+		health.buffer_too_large = true
+	end
+
+	self.__index = self
+	return setmetatable({
+		health = health,
+		bufnr = bufnr,
+		ft = ft,
+		-- XXX(andrea): once we start integrating more with nvim-treesitter we
+		-- should probably pass the lang directly
+		parser = parsers.get_parser(bufnr, lang),
+		query = query,
+		tick = vim.api.nvim_buf_get_changedtick(bufnr),
+	}, Buffer)
+end
+
+function Buffer:valid()
+	return vim.tbl_isempty(self.health)
+end
+
+-- XXX(andrea): if we set we up as nvim-treesitter module do we have to call `parse` on our own?
+function Buffer:root()
+	return self.parser:parse()[1]:root()
+end
+
+function Buffer:changedtick()
+	self.tick = vim.api.nvim_buf_get_changedtick(self.bufnr)
+end
+
+function Buffer:require_refresh()
+	return self.tick ~= vim.api.nvim_buf_get_changedtick(self.bufnr)
+end
+
+function Buffer:identifiers()
+	local root = self:root()
+	local start_row, _, end_row, _ = root:range()
+
+	local identifiers = {}
+	for _, node in self.query:iter_captures(root, self.bufnr, start_row, end_row + 1) do
+		local text = tsq.get_node_text(node, self.bufnr)
+		if text ~= nil then
+			identifiers[text] = true
+		end
+	end
+	return vim.tbl_keys(identifiers)
+end
+
+function Buffer:identifier_at(row, col)
+	for _, node in self.query:iter_captures(self:root(), self.bufnr, row, row + 1) do
+		local start_row, start_col, end_row, end_col = node:range()
+		if start_row == row and end_row == row and start_col < col and end_col >= col then
+			-- XXX(andrea): check if this should be refined or if the first good one is enough
+			return node
+		end
+	end
+end
+
+local function log(msg)
+	vim.api.nvim_out_write(msg .. "\n")
+end
+
+local function collect_and_send_refresh_identifiers(buffer)
+	local fp = vim.api.nvim_buf_get_name(buffer.bufnr)
+	vim.rpcnotify(remote_job_id, "refresh_buffer_identifiers", buffer.ft, fp, buffer:identifiers())
+	buffer:changedtick()
+end
+
+local function show_candidates(id, cands)
+	-- throw away results for out of date requests
+	if last_request.id ~= id then
+		return
+	end
+
+	local candidates = {}
+	for _, candidate in ipairs(cands) do
+		table.insert(candidates, {
+			word = candidate,
+			menu = "[ID]",
+			equal = 1,
+			dup = 1,
+			icase = 1,
+			empty = 1,
+		})
+	end
+
+	-- XXX(andrea): we could make the startcol part of the request to YCM that it
+	-- would then send us back so that we would not store data computed in the
+	-- request phase only to be used on the response phase. I'm not sure how
+	-- better of a design would be :/
+	vim.fn.complete(last_request.startcol, candidates)
+end
+
+local function current_buffer()
+	local bufnr = vim.api.nvim_get_current_buf()
+	local buffer = buffers[bufnr]
+
+	if buffer ~= nil then
+		return buffer
+	end
+
+	buffer = Buffer:new(bufnr)
+	vim.b.ycm_enabled = buffer:valid()
+	buffers[bufnr] = buffer
+
+	return buffer
+end
+
+local function buffer_status()
+	local buffer = current_buffer()
+	if buffer:valid() then
+		log("Enabled in current buffer")
+	else
+		log("Disabled in current buffer: " .. vim.inspect(buffer.health))
+	end
+end
+
+local function refresh_identifiers()
+	local buffer = current_buffer()
+	if buffer:valid() then
+		collect_and_send_refresh_identifiers(buffer)
+	end
+end
+
+local function initialize_buffer()
+	local buffer = current_buffer()
+	if buffer.ft ~= vim.bo.filetype then
+		buffers[buffer.bufnr] = nil
+	end
+
+	refresh_identifiers()
+end
+
+function refresh_identifiers_if_needed()
+	local buffer = current_buffer()
+	if buffer:valid() and buffer:require_refresh() then
+		collect_and_send_refresh_identifiers(buffer)
+	end
+end
+
+-- XXX(andrea): right now ycmd is not able to handle unload of buffers for the
+-- identifier completer (which is what we use). Adding it would require adding
+-- the functionality to ycmd first. See if it is worth it and useful.
+local function on_buf_unload()
+	-- XXX(andrea): check if this is enough
+	-- log( "on_buf_unload "..bufnr)
+	local bufnr = vim.fn.expand("<abuf>")
+	buffers[bufnr] = nil
+	-- XXX(andrea): TODO
+	-- vim.rpcnotify(remote_job_id, "unload", ft, query )
+end
+
+local function get_position()
+	local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+	return row - 1, col
+end
+
+local function complete(buffer)
+	buffer = buffer or current_buffer()
+	if not buffer:valid() then
+		return
+	end
+
+	local row, col = get_position()
+
+	local identifier = buffer:identifier_at(row, col)
+	if identifier == nil then
+		return
+	end
+
+	local input = tsq.get_node_text(identifier, buffer.bufnr)
+	if input == nil then
+		return
+	end
+	local inputlen = input:len()
+
+	if inputlen >= 2 then
+		last_request.id = last_request.id + 1
+		local _, start_col = identifier:range()
+		last_request.startcol = start_col + 1
+
+		vim.rpcnotify(remote_job_id, "complete", last_request.id, buffer.ft, input)
+	end
+end
+
+local function complete_p()
+	local buffer = current_buffer()
+	if not buffer:valid() then
+		return
+	end
+
+	-- if we were called while the popup is visible because we've selected a
+	-- candidate do not do the usual completion work.
+	if not vim.tbl_isempty(vim.v.completed_item) then
+		return
+	end
+
+	complete(buffer)
+end
+
+local function setup_autocmds()
+	local group = vim.api.nvim_create_augroup("ycm", { clear = true })
+	-- XXX(andrea): the FileType event should also handle the case where a
+	-- buffer change Filetype after it is loaded.
+	vim.api.nvim_create_autocmd("FileType", {
+		callback = initialize_buffer,
+		group = group,
+		desc = "initialize buffer when the filetype is available",
+	})
+	-- vim.api.nvim_create_autocmd('FileType', { callback = refresh_identifiers })
+
+	-- XXX(andrea): all the autocmd that follow should actually be for <buffer>
+	-- that has been validated and are compatible. Otherwise we are firing lua
+	-- function only to do checks we already know failed and exit.
+	vim.api.nvim_create_autocmd("BufUnload", {
+		callback = on_buf_unload,
+		group = group,
+		desc = "throw away all the setup done for the buffer including parser",
+	})
+
+	vim.api.nvim_create_autocmd("TextChanged", {
+		callback = refresh_identifiers,
+		group = group,
+		desc = "refresh available identifiers on text change",
+	})
+	vim.api.nvim_create_autocmd("InsertLeave", {
+		callback = refresh_identifiers_if_needed,
+		group = group,
+		desc = "refresh available identifiers only if something happened",
+	})
+
+	vim.api.nvim_create_autocmd("TextChangedI", {
+		callback = function()
+			complete()
+		end,
+		group = group,
+		desc = "register keystroke and start showing possible completions",
+	})
+	vim.api.nvim_create_autocmd("TextChangedP", {
+		callback = complete_p,
+		group = group,
+		desc = "continue filtering but handle candidate selection from the popup menu",
+	})
+end
+
+local function on_exit(...)
+	remote_job_id = nil
+	buffers = {}
+
+	-- This should clear the autocmds.
+	-- XXX(andrea): we should probably put the group name in a variable
+	vim.api.nvim_create_augroup("ycm", { clear = true })
+	-- XXX(andrea): we should:
+	-- * provide a command to setup the plugin again.
+end
+
+-- NOTE: This seems to be the important bit
+local function start_ycm()
+	local bin = plugin_directory .. "/build/bin/ycm"
+	if not vim.fn.executable(bin) then
+		log("The ycm binary is not available. ycm.nvim cannot function without it")
+		return
+	end
+
+	local id = vim.fn.jobstart(bin, { rpc = true, on_exit = on_exit })
+	if id <= 0 then
+		log("Failed to spawn ycm plugin")
+		return
+	end
+	return id
+end
+
+local function define_commands()
+	vim.cmd([[command! YcmStatus lua require('ycm').buffer_status()]])
+end
+
+local function setup()
+	-- XXX(andrea): when https://github.com/neovim/neovim/pull/13479 is merged these would be:
+	-- vim.opt.completeopt = {"menuone", "noinsert", "noselect"}
+	-- vim.opt.shortmess = vim.opt.shortmess + 'c'
+	vim.o.completeopt = "menuone,noinsert,noselect"
+	vim.cmd([[set shortmess+=c]])
+
+	remote_job_id = start_ycm()
+	if remote_job_id ~= nil then
+		setup_autocmds()
+		define_commands()
+
+		-- We might be loaded lazily so we have to try to process the buffer we're in
+		-- the same way we process buffer on FileType set.
+		refresh_identifiers()
+	end
+end
+
+return {
+	setup = setup,
+	buffer_status = buffer_status,
+	show_candidates = show_candidates,
+}

--- a/plugin/lua/spotify-nvim.vim
+++ b/plugin/lua/spotify-nvim.vim
@@ -72,4 +72,4 @@ function! s:rpc(rpcMessage)
 	call rpcnotify(s:spotifyjobid, a:rpcMessage)
 endfunction
 
-call s:init()
+" call s:init()

--- a/plugin/rpc.lua
+++ b/plugin/rpc.lua
@@ -1,0 +1,48 @@
+local plugin_directory = vim.fn.fnamemodify(vim.fn.resolve(vim.fn.expand("<sfile>:p")), ":h:h")
+
+local remote_job_id = nil
+
+local function log(msg)
+	vim.api.nvim_out_write(msg .. "\n")
+end
+
+local function start_plugin()
+	local bin = plugin_directory .. "/target/debug/spotify-vim"
+	if not vim.fn.executable(bin) then
+		log("The nvim-spotify binary is not available.")
+		return
+	end
+
+	local id = vim.fn.jobstart(bin, { rpc = true })
+	if id <= 0 then
+		log("Failed to spawn spotify plugin")
+		return
+	end
+	return id
+end
+
+local function like_song()
+	vim.rpcnotify(remote_job_id, "like")
+	vim.notify_once("rpc request to spotify : like song")
+end
+
+local function define_commands()
+	vim.cmd([[command! SpotifyLike lua like_song() ]])
+	vim.cmd([[command! SpfyDb lua vim.notify('Test!')]])
+end
+
+local function setup()
+	-- vim.opt.completeopt = { "menuone", "noinsert", "noselect" }
+	-- vim.opt.shortmess = vim.opt.shortmess + "c"
+
+	remote_job_id = start_plugin()
+	if remote_job_id ~= nil then
+		-- no autocmds or refreshing? we just need to fire off a rpc request and call it a day
+		define_commands()
+	end
+end
+
+return {
+	setup = setup,
+	like_song = like_song,
+}

--- a/plugin/rpc.lua
+++ b/plugin/rpc.lua
@@ -1,48 +1,38 @@
-local plugin_directory = vim.fn.fnamemodify(vim.fn.resolve(vim.fn.expand("<sfile>:p")), ":h:h")
+-- local plugin_directory = vim.fn.fnamemodify(vim.fn.resolve(vim.fn.expand("<sfile>:p")), ":h:h")
+local spot = {}
 
-local remote_job_id = nil
-
-local function log(msg)
+spot.log = function(msg)
 	vim.api.nvim_out_write(msg .. "\n")
 end
 
-local function start_plugin()
-	local bin = plugin_directory .. "/target/debug/spotify-vim"
-	if not vim.fn.executable(bin) then
-		log("The nvim-spotify binary is not available.")
+local binary_path = vim.fn.fnamemodify(vim.api.nvim_get_runtime_file("plugin/rpc.lua", false)[1], ":h:h")
+	.. "target/debug/spotify-vim"
+
+spot.start = function()
+	if not vim.fn.executable(binary_path) then
+		spot.log("The nvim-spotify binary is not available.")
+		return
+	end
+	print("executable found")
+	spot.id = vim.fn.jobstart({ binary_path }, { rpc = true })
+	if spot.id <= 0 then
+		spot.log("Failed to spawn spotify plugin")
 		return
 	end
 
-	local id = vim.fn.jobstart(bin, { rpc = true })
-	if id <= 0 then
-		log("Failed to spawn spotify plugin")
-		return
-	end
-	return id
+	print("New job...", spot.job_id)
+	spot.cmds()
 end
 
-local function like_song()
-	vim.rpcnotify(remote_job_id, "like")
-	vim.notify_once("rpc request to spotify : like song")
+spot.notify = function(method, ...)
+	spot.start()
+	vim.rpcnotify(spot.id, method, ...)
+	print("Sending rpc notify ...", method)
 end
 
-local function define_commands()
-	vim.cmd([[command! SpotifyLike lua like_song() ]])
+spot.cmds = function()
+	vim.cmd([[command! SpotifyLike lua require'spot'.notify('like') ]])
 	vim.cmd([[command! SpfyDb lua vim.notify('Test!')]])
 end
 
-local function setup()
-	-- vim.opt.completeopt = { "menuone", "noinsert", "noselect" }
-	-- vim.opt.shortmess = vim.opt.shortmess + "c"
-
-	remote_job_id = start_plugin()
-	if remote_job_id ~= nil then
-		-- no autocmds or refreshing? we just need to fire off a rpc request and call it a day
-		define_commands()
-	end
-end
-
-return {
-	setup = setup,
-	like_song = like_song,
-}
+return spot


### PR DESCRIPTION
- FIX: `cargo build` failing due to outdated version for rspotify in Cargo.toml : updated versions
- Vimscript worked (pretty sure) but feels more clunky : Moved to much nicer lua script
- Secreted away other script file for the time being

Known Issues - 
Windows Terminal does not like Neovim launching a browser session : Exits Neovim but doesn't cache auth_token so infinite loop of opening browser and closing Neovim...